### PR TITLE
Conditionally run deploys

### DIFF
--- a/.github/workflows/pr_build.yml
+++ b/.github/workflows/pr_build.yml
@@ -93,4 +93,5 @@ jobs:
   deploy:
     uses: DeskproApps/app-template-vite/.github/workflows/subworkflow-deploy.yml@master
     secrets: inherit
+    if: ${{ github.env.DESKPRO_SERVICE_TOKEN != '' }}
     needs: [deskpro_app_test_and_build]


### PR DESCRIPTION
Dependabot doesn't have secrets (and nor do 3rd parties) so we shouldn't try to deploy unless we have the secret.